### PR TITLE
docker requires iptables to start

### DIFF
--- a/06-F5-WAF-Policy-Management-JuiceShop-Roles/roles/install_docker/tasks/main.yml
+++ b/06-F5-WAF-Policy-Management-JuiceShop-Roles/roles/install_docker/tasks/main.yml
@@ -13,6 +13,11 @@
     name: lvm2
     state: present
 
+- name: install iptables
+  yum:
+    name: iptables
+    state: present
+
 - name: Add Docker GPG key
   rpm_key:
     key: https://download.docker.com/linux/centos/gpg


### PR DESCRIPTION
For some reason this is not getting auto installed in every instance, so am added it to the playbook to ensure it's there.  Docker won't start without this.